### PR TITLE
Use current year and automate clocktable settings

### DIFF
--- a/ii-utils.el
+++ b/ii-utils.el
@@ -60,7 +60,7 @@ This function is INTERACTIVE."
   ""
   (text-mode)
   > "#+TITLE: Timesheet: Week " (setq v1 (skeleton-read "Timesheet Week? "))
-  ", " (setq v2 "2020")
+  ", " (setq v2 (format-time-string "%Y"))
   " (" (getenv "USER") ")" \n
   > "#+AUTHOR: " (getenv "USER") \n
   > " " \n
@@ -68,7 +68,7 @@ This function is INTERACTIVE."
   > " " \n
   > "* Week Summary" \n
   > " " _ \n
-  > "#+BEGIN: clocktable :scope file :block thisweek :maxlevel 2 :emphasise t :tags t :formula %" \n
+  > "#+BEGIN: clocktable :scope file :block " (v2) "-W" (v1) " :maxlevel 2 :emphasise t :tags t :formula %" \n
   > "#+END" \n
   > " " \n
 


### PR DESCRIPTION
Better default settings for `ii/timesheet-skel`
- use the current year when generating the initial time sheet
- lock the clocktable settings to the current ISO week.

Using `thisweek` for [clocktable](https://orgmode.org/manual/The-clock-table.html) is a relative setting where `2021-W20` locks it to that ISO week.

